### PR TITLE
Added ActiveModelSerializers for better json output.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'responders'
 gem 'figaro'
 gem 'colorize'
+gem "active_model_serializers"
 
 group :development, :test do
   gem 'web-console', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,8 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    active_model_serializers (0.9.3)
+      activemodel (>= 3.2)
     activejob (4.2.3)
       activesupport (= 4.2.3)
       globalid (>= 0.3.0)
@@ -199,6 +201,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   apitome
   codeclimate-test-reporter
   coffee-rails (~> 4.1.0)

--- a/app/serializers/item_type_serializer.rb
+++ b/app/serializers/item_type_serializer.rb
@@ -1,0 +1,3 @@
+class ItemTypeSerializer < ActiveModel::Serializer
+  attributes :name
+end

--- a/app/serializers/property_serializer.rb
+++ b/app/serializers/property_serializer.rb
@@ -1,0 +1,3 @@
+class PropertySerializer < ActiveModel::Serializer
+  attributes :name, :group, :category
+end

--- a/app/serializers/rune_serializer.rb
+++ b/app/serializers/rune_serializer.rb
@@ -1,0 +1,3 @@
+class RuneSerializer < ActiveModel::Serializer
+  attributes :name
+end

--- a/app/serializers/runeword_serializer.rb
+++ b/app/serializers/runeword_serializer.rb
@@ -1,0 +1,6 @@
+class RunewordSerializer < ActiveModel::Serializer
+  attributes :name, :ladder_only, :character_level, :item_types, :runes, :properties
+  has_many :runes, serializer: RuneSerializer
+  has_many :properties, serializer: PropertySerializer
+  has_many :item_types, serializer: ItemTypeSerializer
+end


### PR DESCRIPTION
The front end should not have to worry about parsing through created_ats/updated_ats.
Additionally, I want my relations available on the minimum amount of queries. These
issues were solved in one fell swoop by Active Model Serializers.

AMS doesn't deal well with has_and_belongs_to_many relationships. The runewords controller
works just as planned, but now all the other models conform to that particular setup. Ideally
I'm only really concerned with the runewords endpoint anyway.